### PR TITLE
EIWFY23Q4-1 Add Connect Confluence/Jira example schemas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ node_modules
 /src/schema.ts
 *.zip
 /packaged.template
+
+# Editors
+.idea

--- a/src/SchemaApp.tsx
+++ b/src/SchemaApp.tsx
@@ -11,6 +11,7 @@ import { linkToRoot } from './route-path';
 import { ContentPropsWithClose, PrimaryDropdown } from './PrimaryDropdown';
 import { Docs } from './Docs';
 import { getRecentlyViewedLinks, RecentlyViewedLink } from './recently-viewed';
+import { exampleSchemas } from "./example-schemas";
 
 const JsonSchemaHome = () => (
   <ProductHome icon={AtlassianIcon} logo={AtlassianLogo} siteTitle="JSON Schema Viewer" />
@@ -54,16 +55,13 @@ const RecentlyViewedMenu: React.FC<RecentlyViewedMenuProps> = (props) => {
 
 const ExampleMenu: React.FC<ContentPropsWithClose> = (props) => (
   <PopupMenuGroup>
-    <Section title="Schema examples">
-      <NavigationButtonItem onClick={props.closePopup} exampleUrl="https://unpkg.com/@forge/manifest@latest/out/schema/manifest-schema.json">Atlassian Forge</NavigationButtonItem>
-      <NavigationButtonItem onClick={props.closePopup} exampleUrl="https://raw.githubusercontent.com/OAI/OpenAPI-Specification/3.0.3/schemas/v3.0/schema.json">OpenAPI (v3)</NavigationButtonItem>
-      <NavigationButtonItem onClick={props.closePopup} exampleUrl="https://json.schemastore.org/swagger-2.0">Swagger (v2)</NavigationButtonItem>
-      <NavigationButtonItem onClick={props.closePopup} exampleUrl="https://json.schemastore.org/package">package.json</NavigationButtonItem>
-    </Section>
-    <Section title="JSON Schema Meta Schemas">
-      <NavigationButtonItem onClick={props.closePopup} exampleUrl="https://json-schema.org/draft-07/schema">Draft-07</NavigationButtonItem>
-      <NavigationButtonItem onClick={props.closePopup} exampleUrl="https://json-schema.org/draft-04/schema">Draft-04</NavigationButtonItem>
-    </Section>
+    {Array.from(Object.entries(exampleSchemas)).map(([title, links]) => (
+      <Section title={title}>
+        {Array.from(Object.entries(links)).map(([linkTitle, url]) => (
+          <NavigationButtonItem onClick={props.closePopup} exampleUrl={url}>{linkTitle}</NavigationButtonItem>
+          ))}
+      </Section>
+    ))}
     <Section title="Schema repositories">
       <NewTabLinkItem href="https://www.schemastore.org/" onClick={props.closePopup}>Schemastore Repository</NewTabLinkItem>
     </Section>

--- a/src/example-schemas.ts
+++ b/src/example-schemas.ts
@@ -1,0 +1,17 @@
+type ExampleSchemaSection = Record<string, string>
+export const exampleSchemas: Record<string, ExampleSchemaSection> = {
+  "Atlassian schema examples": {
+    "Atlassian Forge": "https://unpkg.com/@forge/manifest@latest/out/schema/manifest-schema.json",
+    "Atlassian Connect - Confluence": "https://bitbucket.org/atlassian/connect-schemas/raw/master/confluence-global-schema.json",
+    "Atlassian Connect - Jira": "https://bitbucket.org/atlassian/connect-schemas/raw/master/jira-global-schema.json"
+  },
+  "Schema examples": {
+    "OpenAPI (v3)": "https://raw.githubusercontent.com/OAI/OpenAPI-Specification/3.0.3/schemas/v3.0/schema.json",
+    "Swagger (v2)": "https://json.schemastore.org/swagger-2.0",
+    "NPM (package.json)": "https://json.schemastore.org/package"
+  },
+  "JSON Schema Meta Schemas": {
+    "Draft-07": "https://json-schema.org/draft-07/schema",
+    "Draft-04": "https://json-schema.org/draft-04/schema"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     // "incremental": true,                   /* Enable incremental compilation */
     "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
-    // "lib": [],                             /* Specify library files to be included in the compilation. */
+     "lib": ["es2017"],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     "jsx": "react",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */


### PR DESCRIPTION
Add Atlassian Connect Confluence and Jira schemas to the list of example schemas, and move them to a dedicated new section for Atlassian schemas.

Cleaned up the menu generation code a bit as well to make it easier to add links in future. Tested this change on my local to confirm it works.
![image](https://github.com/atlassian-labs/json-schema-viewer/assets/92009762/5d19d2ec-fa0c-4527-bf66-ae097acd14e7)
